### PR TITLE
Main.js: Remove jQuery reference

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,7 +1,6 @@
 var app 						= require('app'),
 		browserWindow 	= require('browser-window'),
 		globalShortcut	= require('global-shortcut'),
-		jQuery					= require('jquery'),
 		mainWindow 			= null;
 
 app.on('window-all-closed', function() {


### PR DESCRIPTION
jQuery was removed in a previous commit (https://github.com/Dinius/Brain.fm-Desktop-Client/commit/11f8aa64a36d906561b505e08f971fe4729c35b9) but this file still referenced it as a module.

Fixes Electron app from not starting due to JS error.
