### PR TITLE
Add pause support

### DIFF
--- a/main.js
+++ b/main.js
@@ -33,7 +33,6 @@ app.on('ready', function () {
 
 	// Global shortcuts..
 	globalShortcut.register('MediaNextTrack', function () {skip();});
-	globalShortcut.register('MediaStop', function () {playPause();}); // ?
 	globalShortcut.register('MediaPlayPause', function () {playPause();});
 	//globalShortcut.register('MediaPreviousTrack', function() {});
 
@@ -55,16 +54,5 @@ function playPause() {
 		return;
 	}
 
-	mainWindow.webContents.executeJavaScript('' +
-		'if ($("#play_button").hasClass("tc_pause")) {' +
-		'$("#jquery_jplayer").jPlayer("play", 0);' +
-		'$("#play_button").removeClass("tc_pause").addClass("tc_play");' +
-		'} else {' +
-		'$("#jquery_jplayer").jPlayer("play", 1);' +
-		'$("#play_button").removeClass("tc_play").addClass("tc_pause");' +
-		'}'
-	);
+	mainWindow.webContents.executeJavaScript('$("#play_button").click()');
 }
-
-
-


### PR DESCRIPTION
Thanks for this wrapper app around Brain.fm!

I think you refer to this in the README, but one thing that didn't seem to work for me was pausing - if the app was already playing, the Mac play/pause button seemed to stop and then restart immediately. I made these changes to get play/pause working on Mac which is all I really want from the app, but haven't tested it on Windows or Linux. I also removed the `MediaStop` shortcut since the `playPause` function doesn't have the right behavior for a stop button, at least in its updated form.